### PR TITLE
dex template: enable auto-invoke on plugins

### DIFF
--- a/dotnet/dex-agent/DexBot.cs
+++ b/dotnet/dex-agent/DexBot.cs
@@ -72,21 +72,7 @@ namespace DexAgent
                 config.AUTH_TOKEN = token;
 
                 await orchestrator.CreateChatHistory(turnContext);
-
-                // Check for pull requests
-                if (turnContext.Activity.Text.IndexOf("pull requests", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                    turnContext.Activity.Text.IndexOf("PR", StringComparison.OrdinalIgnoreCase) >= 0)
-                {
-                    KernelArguments args = new KernelArguments();
-                    args.Add("context", turnContext);
-                    var result = await kernel.InvokeAsync("GitHubPlugin", "ListPRs", args, cancellationToken);
-                    string activity = result.GetValue<string>();
-                    await orchestrator.SaveActivityToChatHistory(turnContext, activity);
-                }
-                else
-                {
                     await orchestrator.GetChatMessageContentAsync(turnContext);
-                }
             });
 
             app.Authentication.Get(config.OAUTH_CONNECTION_NAME).OnUserSignInSuccess(async (context, state) =>

--- a/dotnet/dex-agent/DexBot.cs
+++ b/dotnet/dex-agent/DexBot.cs
@@ -72,7 +72,7 @@ namespace DexAgent
                 config.AUTH_TOKEN = token;
 
                 await orchestrator.CreateChatHistory(turnContext);
-                    await orchestrator.GetChatMessageContentAsync(turnContext);
+                await orchestrator.GetChatMessageContentAsync(turnContext);
             });
 
             app.Authentication.Get(config.OAUTH_CONNECTION_NAME).OnUserSignInSuccess(async (context, state) =>

--- a/dotnet/dex-agent/GitHubPlugin.cs
+++ b/dotnet/dex-agent/GitHubPlugin.cs
@@ -25,10 +25,11 @@ namespace DexAgent
         }
 
         /// <summary>
-        /// Lists the pull requests for the repository
+        /// Lists the pull requests for GitHub.
+        /// Note that the activity is auto saved to history.
         /// </summary>
-        /// <param name="context">The turn context</param>
-        /// <returns>Serialized adaptive card activity</returns>
+        /// <param name="kernel">The associated kernel instance.</param>
+        /// <returns>A serialized adaptive card string of the pull requests.</returns>
         /// <exception cref="Exception"></exception>
         [KernelFunction, Description("Lists the pull requests")]
         public override async Task<string> ListPRs(Kernel kernel)
@@ -140,9 +141,9 @@ namespace DexAgent
            [Description("The turn context")] TurnContext context,
            [Description("The pull requests")] IList<GitHubPR> pullRequests)
         {
-            var labelsArr = string.IsNullOrEmpty(labels) ? new string[0] : labels.Split(',');
-            var assigneesArr = string.IsNullOrEmpty(assignees) ? new string[0] : assignees.Split(',');
-            var authorsArr = string.IsNullOrEmpty(authors) ? new string[0] : authors.Split(',');
+            var labelsArr = string.IsNullOrEmpty(labels) ? Array.Empty<string>() : labels.Split(',');
+            var assigneesArr = string.IsNullOrEmpty(assignees) ? Array.Empty<string>() : assignees.Split(',');
+            var authorsArr = string.IsNullOrEmpty(authors) ? Array.Empty<string>() : authors.Split(',');
 
             var filteredPullRequests = pullRequests.Where(pr =>
                 (labelsArr.Length == 0 || pr.Labels.Any(label => labelsArr.Contains(label.Name))) &&

--- a/dotnet/dex-agent/GitHubPlugin.cs
+++ b/dotnet/dex-agent/GitHubPlugin.cs
@@ -31,9 +31,11 @@ namespace DexAgent
         /// <returns>Serialized adaptive card activity</returns>
         /// <exception cref="Exception"></exception>
         [KernelFunction, Description("Lists the pull requests")]
-        public override async Task<string> ListPRs(
-            [Description("The turn context")] TurnContext context)
+        public override async Task<string> ListPRs(Kernel kernel)
         {
+            kernel.Data.TryGetValue("context", out object turnContext);
+            TurnContext context = turnContext as TurnContext;
+
             try
             {
                 string owner = Config.GITHUB_OWNER;

--- a/dotnet/dex-agent/Interfaces/IRepositoryPlugin.cs
+++ b/dotnet/dex-agent/Interfaces/IRepositoryPlugin.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
-using Microsoft.SemanticKernel;
+﻿using Microsoft.SemanticKernel;
 using System.ComponentModel;
 
 namespace DexAgent.Interfaces
@@ -15,6 +13,7 @@ namespace DexAgent.Interfaces
         /// The HTTP client used for making API requests.
         /// </summary>
         public HttpClient HttpClient { get; set; }
+
         /// <summary>
         /// Provides access to keys for auth.
         /// </summary>
@@ -23,7 +22,7 @@ namespace DexAgent.Interfaces
         /// <summary>
         /// Lists the pull requests for the repository.
         /// </summary>
-        /// <param name="context">The turn context</param>
+        /// <param name="kernel">The associated kernel instance.</param>
         /// <returns>A serialized adaptive card string of the pull requests.</returns>
         [KernelFunction, Description("Lists the pull requests")]
         public abstract Task<string> ListPRs(Kernel kernel);

--- a/dotnet/dex-agent/Interfaces/IRepositoryPlugin.cs
+++ b/dotnet/dex-agent/Interfaces/IRepositoryPlugin.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
 using Microsoft.SemanticKernel;
 using System.ComponentModel;
 
@@ -25,7 +26,6 @@ namespace DexAgent.Interfaces
         /// <param name="context">The turn context</param>
         /// <returns>A serialized adaptive card string of the pull requests.</returns>
         [KernelFunction, Description("Lists the pull requests")]
-        public abstract Task<string> ListPRs(
-           [Description("The turn context")] TurnContext context);
+        public abstract Task<string> ListPRs(Kernel kernel);
     }
 }

--- a/dotnet/dex-agent/KernelOrchestrator.cs
+++ b/dotnet/dex-agent/KernelOrchestrator.cs
@@ -171,8 +171,7 @@ namespace DexAgent
 
                 // Responses from LLM may vary by key
                 var chunkJson = JsonSerializer.Deserialize<JsonElement>(chunkBuilder.ToString());
-                string[] resultKeys = ["message", "response", "capabilities"];
-
+                string[] resultKeys = new string[] { "message", "response", "capabilities" };
                 foreach (var key in resultKeys)
                 {
                     if (chunkJson.TryGetProperty(key, out JsonElement val))

--- a/dotnet/dex-agent/KernelOrchestrator.cs
+++ b/dotnet/dex-agent/KernelOrchestrator.cs
@@ -117,8 +117,7 @@ namespace DexAgent
 
                 var resultJson = JsonSerializer.Deserialize<JsonElement>(result.Content);
                 // Responses from LLM may vary by key
-                string[] resultKeys = ["message", "response", "capabilities"];
-
+                string[] resultKeys = new string[] { "message", "response", "capabilities" };
                 foreach (var key in resultKeys)
                 {
                     string finalStr = "";

--- a/dotnet/dex-agent/KernelOrchestrator.cs
+++ b/dotnet/dex-agent/KernelOrchestrator.cs
@@ -125,7 +125,11 @@ namespace DexAgent
                     {
                         finalStr += val.ToString();
                     }
-                    await turnContext.SendActivityAsync(finalStr);
+
+                    if (!string.IsNullOrEmpty(finalStr))
+                    {
+                        await turnContext.SendActivityAsync(finalStr);
+                    }
                 }
             }
         }

--- a/dotnet/dex-agent/README.md
+++ b/dotnet/dex-agent/README.md
@@ -135,5 +135,7 @@ Then, update the plugin provided during the Semantic Kernel registration.
 
 Please use the methods inside `KernelOrchestrator` to manage conversation history. 
 
+Update the string comparison of `GitHubPlugin-ListPRs` in `GetChatMessageContentAsyncForOneToOneScenarios`.
+
 Be sure to also update the prompt
 in `KernelOrchestrator.InitiateChat`.

--- a/dotnet/dex-agent/README.md
+++ b/dotnet/dex-agent/README.md
@@ -6,7 +6,7 @@ The agent is designed to reduce time-consuming tasks, enhance efficiency, and el
 
 ## Key Features
 - 📄 **List Pull Requests**: Displays a list of your repository's pull requests
-- 🔍 **Filter Pull Requests**: Find PRs based on labels, assignees, and/or authors
+- 🔍 **Filter Pull Requests**: Filter PRs based on labels, assignees, and/or authors
 - 🔔 **Proactive Alerts on PR Assignments**: Be notified in group chats and channels when there is a new assignee on a PR
 - 🔔 **Proactive Alerts on PR Status Changes**: Be notified in group chats and channels when there is a status update on a PR
 
@@ -81,8 +81,8 @@ More information is available [here](https://docs.github.com/en/apps/creating-gi
 Although this agent is currently configured to use GitHub, you can easily swap for another repository tool.
 
 Note the restrictions:
-- Only one tool can be configured at a time, due to the Azure Bicep file deployments.
-- Different tools require different API keys, hence these will need to be added manually.
+- Only one repository tool can be configured at a time, due to the Azure Bicep file deployments.
+- Different repository tools require different API keys, hence these will need to be added manually.
 - Authentication is restricted to `Oauth Azure Bot Service Providers`.
 
 There are a few components. You may define your own structs similar to those in `GitHubModels`
@@ -94,12 +94,11 @@ There are a few components. You may define your own structs similar to those in 
 Replace the GitHub values with your new tool.
 
 ### 2) Activity Handlers
-All handlers are registered in `Program.cs`. These can be easily updated and customized. 
+All handlers are registered in `DexBot.cs`. These can be easily updated and customized. 
 
-The two to update for `ListPRs` are:
- `app.AdaptiveCards.OnActionSubmit(...)` and `app.OnActivity(ActivityTypes.Message...)`
+`ListPRs` is auto-invoked by the kernel via `app.OnActivity(ActivityTypes.Message...)`
 
- The latter generic message handler is used to route messages to Semantic Kernel.
+`FilterPRs` is manually invoked via `app.AdaptiveCards.OnActionSubmit(...)`
 
 ### 3) Webhooks
 All webhook URLs must start with `api/webhook`.
@@ -131,8 +130,6 @@ Then, update the plugin provided during the Semantic Kernel registration.
  GitHubPlugin plugin = (GitHubPlugin)repoService.RepositoryPlugin;
  kernelBuilder.Plugins.AddFromObject(plugin, "GitHubPlugin");
 ```
-
-Both ListPRs and FilterPRs are manually invoked via the activity handlers, to allow the rendering of adaptive cards. 
 
 ### 5) Conversation Management
 


### PR DESCRIPTION
subtle nuances
- teams streaming is only currently enabled for 1:1 chats 
- proper streaming for teams adaptive cards is yet to be available 

- semantic kernel oddly returns different keys sometimes with `json_object`
   - either `message`, `response`, `capabilities`, `features`

- plugins + streaming
  - tool call info is only available in the second chunk, I had to add a flag when processing subsequent chunks
  - as a result of all of these, I had to manually rechunk

- tool calls are automatically **added** to chat history- so we only need to **save** to history