### PR TITLE
Update Collaborator Agent README.md

### DIFF
--- a/js/collaborator-agent/README.md
+++ b/js/collaborator-agent/README.md
@@ -17,6 +17,7 @@ tags:
   - "conversation-analysis"
   - "task-management"
 githubUrl: "https://github.com/microsoft/teams-agent-accelerator-templates/blob/main/js/collaborator-agent"
+imageUrl: ""
 author: "Microsoft"
 language: "TypeScript"
 demoYoutubeVideoId: "RuIfcNcBB_8"


### PR DESCRIPTION
Missing `imageUrl` is breaking the template gallery site 