### PR TITLE
Bump WorkIQ Agent package versions

### DIFF
--- a/dotnet/A365TeamsAgent/A365TeamsAgent/A365TeamsAgent.csproj
+++ b/dotnet/A365TeamsAgent/A365TeamsAgent/A365TeamsAgent.csproj
@@ -11,7 +11,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Teams.Apps" Version="2.1.0-preview-0030-g1540b5a45b" />
+		<PackageReference Include="Microsoft.Teams.Apps" Version="2.1.0-preview-0008" />
 	</ItemGroup>
 
 </Project>

--- a/dotnet/A365TeamsAgent/WorkIQ.Agent/WorkIQ.Agent.csproj
+++ b/dotnet/A365TeamsAgent/WorkIQ.Agent/WorkIQ.Agent.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Teams.Apps" Version="2.1.0-preview-0030-g1540b5a45b" />
+		<PackageReference Include="Microsoft.Teams.Apps" Version="2.1.0-preview-0008" />
 		<PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
 		<PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
 		<PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
@@ -15,9 +15,9 @@
 		<PackageReference Include="Microsoft.OpenTelemetry" Version="1.0.5" />
 		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Keep the WorkIQ Agent dependencies aligned with the current OpenTelemetry line and the pinned Microsoft.Teams.Apps preview build used by the project. This is a dependency-only refresh with no intended product logic changes.

## What changed
- Updated `Microsoft.Teams.Apps` to `2.1.0-preview-0008`
- Bumped `OpenTelemetry.Instrumentation.AspNetCore`, `OpenTelemetry.Instrumentation.Http`, and `OpenTelemetry.Instrumentation.Runtime` to `1.16.0`

## Notes
- No source behavior changes are intended; this is package maintenance only.